### PR TITLE
Add script to append domains to Squid blocklist

### DIFF
--- a/shell code/add_block.sh
+++ b/shell code/add_block.sh
@@ -1,0 +1,20 @@
+
+#!/usr/bin/env bash
+set -euo pipefail
+
+BLOCK="/etc/squid/blocklist.txt"
+
+if [ $# -lt 1 ]; then
+  echo "Usage: sudo ./add_block.sh <domain>"
+  exit 1
+fi
+
+DOMAIN="$1"
+if ! grep -qi "^${DOMAIN}$" "$BLOCK" 2>/dev/null; then
+  echo "$DOMAIN" | sudo tee -a "$BLOCK" >/dev/null
+  echo "[✓] Added $DOMAIN to blocklist."
+else
+  echo "[*] $DOMAIN already present."
+fi
+
+sudo systemctl reload squid


### PR DESCRIPTION
Introduces add_block.sh, a Bash script to add a domain to /etc/squid/blocklist.txt if not already present and reload the Squid service. Provides usage instructions and handles duplicate entries.